### PR TITLE
Remove "repo"-field

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "type": "git",
     "url": "https://github.com/RobLoach/docpad-plugin-htmlmin.git"
   },
-  "repo": "RobLoach/docpad-plugin-htmlmin",
   "engines": {
     "node": ">=0.4",
     "docpad": "6.x"


### PR DESCRIPTION
When installing with `npm install` the following warning is generated:
npm WARN package.json docpad-plugin-htmlmin@2.4.0 repo should probably be repository.
